### PR TITLE
Update install-from-source.yml

### DIFF
--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -5,6 +5,7 @@
     - '@development'
     - zlib-devel
     - openssl-static
+    - readline-devel
   when: ansible_os_family == 'RedHat'
 
 - name: Update apt cache (Debian).


### PR DESCRIPTION
Add readline-devel to the packages required to build Ruby. This is required primarily due to `rails c` not working on a machine I've used this playbook to build Ruby on.